### PR TITLE
update dockerfile to make it mucho smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,21 @@
 FROM iron/go:dev as builder
+
 WORKDIR /go/src/github.com/vapor-ware/synse-amt-plugin
 COPY . .
-RUN make build GIT_TAG="" GIT_COMMIT=""
+
+RUN make build
 
 
-FROM python:3.6-alpine
+FROM iron/go
 LABEL maintainer="vapor@vapor.io"
 
-RUN apk add go --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ --allow-untrusted
+WORKDIR /plugin
 
 COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
-
-WORKDIR /plugin
+RUN apk --update --no-cache add python2 \
+    && apk --update --no-cache --virtual .build-dep add py2-pip \
+    && pip install -r requirements.txt \
+    && apk del .build-dep
 
 COPY --from=builder /go/src/github.com/vapor-ware/synse-amt-plugin/build/plugin ./plugin
 COPY config.yml .

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PLUGIN_NAME    := amt
-PLUGIN_VERSION := 0.1.0-alpha
+PLUGIN_VERSION := 0.1.1-alpha
 IMAGE_NAME     := vaporio/amt-plugin
 
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2> /dev/null || true)


### PR DESCRIPTION
played around with the dockerfile a bit more this weekend. turns out that I had it backwards before and using the slim go image as the base results in a smaller image overall. 

note: this uses python2 because apk doesn't have python3-pip in is stable packages, that I could find.

with this, I'm getting an image of ~66MB whereas before it was ~498MB
